### PR TITLE
Host: Cleaning up logs and lifetime on systemd

### DIFF
--- a/Kyoo.Core/Kyoo.Core.csproj
+++ b/Kyoo.Core/Kyoo.Core.csproj
@@ -23,10 +23,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="5.0.1" />
 		<PackageReference Include="Serilog" Version="2.10.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
 		<PackageReference Include="Serilog.Expressions" Version="3.2.0" />
+		<PackageReference Include="Serilog.Sinks.SyslogMessages" Version="2.0.6" />
 		<PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
 		<PackageReference Include="Autofac" Version="6.2.0" />
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />

--- a/deployment/kyoo.service
+++ b/deployment/kyoo.service
@@ -9,6 +9,8 @@ Environment=KYOO_DATADIR=/var/lib/kyoo
 ExecStart=/usr/lib/kyoo/Kyoo.Host.Console
 Restart=on-abort
 TimeoutSec=20
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Proposed changes

Cleaning up logs for systemd hosted applications.
Using a specific SystemdLifetime instead of the default ConsoleLifetime.

## Information
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] New public API added
 - [x] Non-breaking changes