### PR TITLE
Remove public url

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ services:
         restart: on-failure
         environment:
             - KYOO_DATADIR=/var/lib/kyoo
-            - BASICS__PUBLICURL=https://demo.kyoo.moe
             - DATABASE__ENABLED=postgres
             - DATABASE__CONFIGURATIONS__POSTGRES__SERVER=postgres
             - DATABASE__CONFIGURATIONS__POSTGRES__USER ID=kyoo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     restart: on-failure
     environment:
       - KYOO_DATADIR=/var/lib/kyoo
-      - BASICS__PUBLICURL=http://localhost:5000
       - DATABASE__ENABLED=postgres
       - DATABASE__CONFIGURATIONS__POSTGRES__SERVER=postgres
       - DATABASE__CONFIGURATIONS__POSTGRES__USER=kyoo

--- a/docs/start/setting_up.md
+++ b/docs/start/setting_up.md
@@ -22,7 +22,6 @@ We are going to take a look at the fields you might want to change to tailor Kyo
 
 - ```basics```
   - ```url```: The port on which Kyoo will be exposed
-  - ```publicUrl```: The full URL for Kyoo.
   For the 3 following fields, the path are relative to the directory ```settings.json``` is in
   - ```pluginsPath```: The directory where the plugins are stored
   - ```transmuxPath```: The directory where the transmux-ed video are stored (used as a cache)
@@ -34,7 +33,7 @@ We are going to take a look at the fields you might want to change to tailor Kyo
 - ```tasks```
   - ```parallels```: The number of tasks that can be run at the same time. If the values is not ```1```, the behavior is not implemented.
   - ```scheduled```: An object with keys being the name of an automation task, with a value being the interval between each task of the same type.
-    - The available keys can be found at ```publicUrl/api/tasks``` (as 'slug')
+    - The available keys can be found at ```/api/tasks``` (as 'slug')
     - The values must be formatted like ```HH:MM:SS``
     **For Example** in the default configuration, a file scan task will be executed every 24 hours
 
@@ -81,7 +80,7 @@ If everything looks normal, no error message will appear, just log messages.
 Then, we are going to interact with Kyoo's API. To create a library, you must do the following request for each library you want to make:
   
 - POST Request
-- At ```publicUrl/api/libraries``` (```publicUrl``` is in ```settings.json```)
+- At ```/api/libraries```
 - Content-Type: ```application/json```
 - Body:
 
@@ -97,6 +96,6 @@ Then, we are going to interact with Kyoo's API. To create a library, you must do
     }
     ```
 
-Now that you created your libraries, you can do a simple GET request to ```publicUrl/api/task/scan``` to scan for videos in all the libraries.
+Now that you created your libraries, you can do a simple GET request to ```/api/task/scan``` to scan for videos in all the libraries.
 
 Once the scan is over, ```Task finished: Scan Libraries``` will be displayed! You are now ready to use Kyoo!

--- a/src/Kyoo.Abstractions/Module.cs
+++ b/src/Kyoo.Abstractions/Module.cs
@@ -91,15 +91,5 @@ namespace Kyoo.Abstractions
 		{
 			return builder.RegisterRepository<T2>().As<T>();
 		}
-
-		/// <summary>
-		/// Get the public URL of kyoo using the given configuration instance.
-		/// </summary>
-		/// <param name="configuration">The configuration instance</param>
-		/// <returns>The public URl of kyoo (without a slash at the end)</returns>
-		public static Uri GetPublicUrl(this IConfiguration configuration)
-		{
-			return new Uri(configuration["basics:publicUrl"] ?? "http://localhost:5000");
-		}
 	}
 }

--- a/src/Kyoo.Authentication/AuthenticationModule.cs
+++ b/src/Kyoo.Authentication/AuthenticationModule.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Autofac;
-using Kyoo.Abstractions;
 using Kyoo.Abstractions.Controllers;
 using Kyoo.Authentication.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -76,7 +75,6 @@ namespace Kyoo.Authentication
 		/// <inheritdoc />
 		public void Configure(IServiceCollection services)
 		{
-			Uri publicUrl = _configuration.GetPublicUrl();
 			AuthenticationOption jwt = ConfigurationBinder.Get<AuthenticationOption>(
 				_configuration.GetSection(AuthenticationOption.Path)
 			);
@@ -87,12 +85,10 @@ namespace Kyoo.Authentication
 				{
 					options.TokenValidationParameters = new TokenValidationParameters
 					{
-						ValidateIssuer = true,
-						ValidateAudience = true,
+						ValidateIssuer = false,
+						ValidateAudience = false,
 						ValidateLifetime = true,
 						ValidateIssuerSigningKey = true,
-						ValidIssuer = publicUrl.ToString(),
-						ValidAudience = publicUrl.ToString(),
 						IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.Secret))
 					};
 				});

--- a/src/Kyoo.Authentication/Controllers/TokenController.cs
+++ b/src/Kyoo.Authentication/Controllers/TokenController.cs
@@ -24,10 +24,8 @@ using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
-using Kyoo.Abstractions;
 using Kyoo.Abstractions.Models;
 using Kyoo.Authentication.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
@@ -44,19 +42,12 @@ namespace Kyoo.Authentication
 		private readonly IOptions<AuthenticationOption> _options;
 
 		/// <summary>
-		/// The configuration used to retrieve the public URL of kyoo.
-		/// </summary>
-		private readonly IConfiguration _configuration;
-
-		/// <summary>
 		/// Create a new <see cref="TokenController"/>.
 		/// </summary>
 		/// <param name="options">The options that this controller will use.</param>
-		/// <param name="configuration">The configuration used to retrieve the public URL of kyoo.</param>
-		public TokenController(IOptions<AuthenticationOption> options, IConfiguration configuration)
+		public TokenController(IOptions<AuthenticationOption> options)
 		{
 			_options = options;
-			_configuration = configuration;
 		}
 
 		/// <inheritdoc />
@@ -80,8 +71,6 @@ namespace Kyoo.Authentication
 				claims.Add(new Claim(Claims.Email, user.Email));
 			JwtSecurityToken token = new(
 				signingCredentials: credential,
-				issuer: _configuration.GetPublicUrl().ToString(),
-				audience: _configuration.GetPublicUrl().ToString(),
 				claims: claims,
 				expires: DateTime.UtcNow.Add(expireIn)
 			);
@@ -95,8 +84,6 @@ namespace Kyoo.Authentication
 			SigningCredentials credential = new(key, SecurityAlgorithms.HmacSha256Signature);
 			JwtSecurityToken token = new(
 				signingCredentials: credential,
-				issuer: _configuration.GetPublicUrl().ToString(),
-				audience: _configuration.GetPublicUrl().ToString(),
 				claims: new[]
 				{
 					new Claim(Claims.Id, user.ID.ToString(CultureInfo.InvariantCulture)),
@@ -119,12 +106,10 @@ namespace Kyoo.Authentication
 			{
 				principal = tokenHandler.ValidateToken(refreshToken, new TokenValidationParameters
 				{
-					ValidateIssuer = true,
-					ValidateAudience = true,
+					ValidateIssuer = false,
+					ValidateAudience = false,
 					ValidateIssuerSigningKey = true,
 					ValidateLifetime = true,
-					ValidIssuer = _configuration.GetPublicUrl().ToString(),
-					ValidAudience = _configuration.GetPublicUrl().ToString(),
 					IssuerSigningKey = key
 				}, out SecurityToken _);
 			}

--- a/src/Kyoo.Authentication/Views/AuthApi.cs
+++ b/src/Kyoo.Authentication/Views/AuthApi.cs
@@ -40,7 +40,7 @@ namespace Kyoo.Authentication.Views
 	/// Sign in, Sign up or refresh tokens.
 	/// </summary>
 	[ApiController]
-	[Route("api/auth")]
+	[Route("auth")]
 	[ApiDefinition("Authentication", Group = UsersGroup)]
 	public class AuthApi : ControllerBase
 	{

--- a/src/Kyoo.Core/Models/Options/BasicOptions.cs
+++ b/src/Kyoo.Core/Models/Options/BasicOptions.cs
@@ -16,8 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
-
 namespace Kyoo.Core.Models.Options
 {
 	/// <summary>
@@ -34,11 +32,6 @@ namespace Kyoo.Core.Models.Options
 		/// The internal url where the server will listen. It supports globing.
 		/// </summary>
 		public string Url { get; set; } = "http://*:5000";
-
-		/// <summary>
-		/// The public url that will be used in items response and in authentication server host.
-		/// </summary>
-		public Uri PublicUrl { get; set; } = new("http://localhost:5000");
 
 		/// <summary>
 		/// The path of the plugin directory.

--- a/src/Kyoo.Core/Views/Admin/ConfigurationApi.cs
+++ b/src/Kyoo.Core/Views/Admin/ConfigurationApi.cs
@@ -31,8 +31,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// An API to retrieve or edit configuration settings
 	/// </summary>
-	[Route("api/configuration")]
-	[Route("api/config", Order = AlternativeRoute)]
+	[Route("configuration")]
+	[Route("config", Order = AlternativeRoute)]
 	[ApiController]
 	[PartialPermission("Configuration", Group = Group.Admin)]
 	[ApiDefinition("Configuration", Group = AdminGroup)]

--- a/src/Kyoo.Core/Views/Admin/TaskApi.cs
+++ b/src/Kyoo.Core/Views/Admin/TaskApi.cs
@@ -32,8 +32,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// An endpoint to list and run tasks in the background.
 	/// </summary>
-	[Route("api/tasks")]
-	[Route("api/task", Order = AlternativeRoute)]
+	[Route("tasks")]
+	[Route("task", Order = AlternativeRoute)]
 	[ApiController]
 	[ResourceView]
 	[PartialPermission("Task", Group = Group.Admin)]

--- a/src/Kyoo.Core/Views/Helper/BaseApi.cs
+++ b/src/Kyoo.Core/Views/Helper/BaseApi.cs
@@ -45,12 +45,9 @@ namespace Kyoo.Core.Api
 		protected Page<TResult> Page<TResult>(ICollection<TResult> resources, int limit)
 			where TResult : IResource
 		{
-			Uri publicUrl = HttpContext.RequestServices
-				.GetRequiredService<IConfiguration>()
-				.GetPublicUrl();
 			return new Page<TResult>(
 				resources,
-				new Uri(publicUrl, Request.Path),
+				new Uri(Request.Path),
 				Request.Query.ToDictionary(
 					x => x.Key,
 					x => x.Value.ToString(),

--- a/src/Kyoo.Core/Views/Helper/BaseApi.cs
+++ b/src/Kyoo.Core/Views/Helper/BaseApi.cs
@@ -19,11 +19,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Kyoo.Abstractions;
 using Kyoo.Abstractions.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Kyoo.Core.Api
 {

--- a/src/Kyoo.Core/Views/Helper/Serializers/JsonOptions.cs
+++ b/src/Kyoo.Core/Views/Helper/Serializers/JsonOptions.cs
@@ -35,29 +35,20 @@ namespace Kyoo.Core.Api
 		private readonly IHttpContextAccessor _httpContextAccessor;
 
 		/// <summary>
-		/// The options containing the public URL of kyoo, given to <see cref="JsonSerializerContract"/>.
-		/// </summary>
-		private readonly IOptions<BasicOptions> _options;
-
-		/// <summary>
 		/// Create a new <see cref="JsonOptions"/>.
 		/// </summary>
 		/// <param name="httpContextAccessor">
 		/// The http context accessor given to the <see cref="JsonSerializerContract"/>.
 		/// </param>
-		/// <param name="options">
-		/// The options containing the public URL of kyoo, given to <see cref="JsonSerializerContract"/>.
-		/// </param>
-		public JsonOptions(IHttpContextAccessor httpContextAccessor, IOptions<BasicOptions> options)
+		public JsonOptions(IHttpContextAccessor httpContextAccessor)
 		{
 			_httpContextAccessor = httpContextAccessor;
-			_options = options;
 		}
 
 		/// <inheritdoc />
 		public void Configure(MvcNewtonsoftJsonOptions options)
 		{
-			options.SerializerSettings.ContractResolver = new JsonSerializerContract(_httpContextAccessor, _options);
+			options.SerializerSettings.ContractResolver = new JsonSerializerContract(_httpContextAccessor);
 			options.SerializerSettings.Converters.Add(new PeopleRoleConverter());
 		}
 	}

--- a/src/Kyoo.Core/Views/Helper/Serializers/JsonSerializerContract.cs
+++ b/src/Kyoo.Core/Views/Helper/Serializers/JsonSerializerContract.cs
@@ -107,7 +107,7 @@ namespace Kyoo.Core.Api
 						IThumbnails thumb = (IThumbnails)x;
 						return thumb?.Images?.ContainsKey(id) == true;
 					},
-					ValueProvider = new ThumbnailProvider(_options.Value.PublicUrl, id)
+					ValueProvider = new ThumbnailProvider(id)
 				});
 			}
 
@@ -121,11 +121,6 @@ namespace Kyoo.Core.Api
 		private class ThumbnailProvider : IValueProvider
 		{
 			/// <summary>
-			/// The public address of kyoo.
-			/// </summary>
-			private readonly Uri _host;
-
-			/// <summary>
 			/// The index/ID of the image to retrieve/set.
 			/// </summary>
 			private readonly int _imageIndex;
@@ -133,11 +128,9 @@ namespace Kyoo.Core.Api
 			/// <summary>
 			/// Create a new <see cref="ThumbnailProvider"/>.
 			/// </summary>
-			/// <param name="host">The public address of kyoo.</param>
 			/// <param name="imageIndex">The index/ID of the image to retrieve/set.</param>
-			public ThumbnailProvider(Uri host, int imageIndex)
+			public ThumbnailProvider(int imageIndex)
 			{
-				_host = host;
 				_imageIndex = imageIndex;
 			}
 
@@ -160,7 +153,7 @@ namespace Kyoo.Core.Api
 				string type = target is ICustomTypeDescriptor descriptor
 					? descriptor.GetClassName()
 					: target.GetType().Name;
-				return new Uri(_host, $"/api/{type}/{slug}/{Images.ImageName[_imageIndex]}".ToLower())
+				return new Uri($"/api/{type}/{slug}/{Images.ImageName[_imageIndex]}".ToLowerInvariant())
 					.ToString();
 			}
 		}

--- a/src/Kyoo.Core/Views/Helper/Serializers/JsonSerializerContract.cs
+++ b/src/Kyoo.Core/Views/Helper/Serializers/JsonSerializerContract.cs
@@ -22,9 +22,7 @@ using System.ComponentModel;
 using System.Reflection;
 using Kyoo.Abstractions.Models;
 using Kyoo.Abstractions.Models.Attributes;
-using Kyoo.Core.Models.Options;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -44,19 +42,12 @@ namespace Kyoo.Core.Api
 		private readonly IHttpContextAccessor _httpContextAccessor;
 
 		/// <summary>
-		/// The options containing the public URL of kyoo.
-		/// </summary>
-		private readonly IOptions<BasicOptions> _options;
-
-		/// <summary>
 		/// Create a new <see cref="JsonSerializerContract"/>.
 		/// </summary>
 		/// <param name="httpContextAccessor">The http context accessor to use.</param>
-		/// <param name="options">The options containing the public URL of kyoo.</param>
-		public JsonSerializerContract(IHttpContextAccessor httpContextAccessor, IOptions<BasicOptions> options)
+		public JsonSerializerContract(IHttpContextAccessor httpContextAccessor)
 		{
 			_httpContextAccessor = httpContextAccessor;
-			_options = options;
 		}
 
 		/// <inheritdoc />
@@ -153,7 +144,7 @@ namespace Kyoo.Core.Api
 				string type = target is ICustomTypeDescriptor descriptor
 					? descriptor.GetClassName()
 					: target.GetType().Name;
-				return new Uri($"/api/{type}/{slug}/{Images.ImageName[_imageIndex]}".ToLowerInvariant())
+				return new Uri($"/{type}/{slug}/{Images.ImageName[_imageIndex]}".ToLowerInvariant())
 					.ToString();
 			}
 		}

--- a/src/Kyoo.Core/Views/Metadata/GenreApi.cs
+++ b/src/Kyoo.Core/Views/Metadata/GenreApi.cs
@@ -34,8 +34,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// Information about one or multiple <see cref="Genre"/>.
 	/// </summary>
-	[Route("api/genres")]
-	[Route("api/genre", Order = AlternativeRoute)]
+	[Route("genres")]
+	[Route("genre", Order = AlternativeRoute)]
 	[ApiController]
 	[PartialPermission(nameof(Genre))]
 	[ApiDefinition("Genres", Group = MetadataGroup)]

--- a/src/Kyoo.Core/Views/Metadata/ProviderApi.cs
+++ b/src/Kyoo.Core/Views/Metadata/ProviderApi.cs
@@ -30,8 +30,8 @@ namespace Kyoo.Core.Api
 	/// Providers are links to external websites or database.
 	/// They are mostly linked to plugins that provide metadata from those websites.
 	/// </summary>
-	[Route("api/providers")]
-	[Route("api/provider", Order = AlternativeRoute)]
+	[Route("providers")]
+	[Route("provider", Order = AlternativeRoute)]
 	[ApiController]
 	[ResourceView]
 	[PartialPermission(nameof(Provider))]

--- a/src/Kyoo.Core/Views/Metadata/StaffApi.cs
+++ b/src/Kyoo.Core/Views/Metadata/StaffApi.cs
@@ -35,8 +35,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// Information about one or multiple staff member.
 	/// </summary>
-	[Route("api/staff")]
-	[Route("api/people", Order = AlternativeRoute)]
+	[Route("staff")]
+	[Route("people", Order = AlternativeRoute)]
 	[ApiController]
 	[ResourceView]
 	[PartialPermission(nameof(People))]

--- a/src/Kyoo.Core/Views/Metadata/StudioApi.cs
+++ b/src/Kyoo.Core/Views/Metadata/StudioApi.cs
@@ -34,8 +34,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// Information about one or multiple <see cref="Studio"/>.
 	/// </summary>
-	[Route("api/studios")]
-	[Route("api/studio", Order = AlternativeRoute)]
+	[Route("studios")]
+	[Route("studio", Order = AlternativeRoute)]
 	[ApiController]
 	[PartialPermission(nameof(Show))]
 	[ApiDefinition("Studios", Group = MetadataGroup)]

--- a/src/Kyoo.Core/Views/Resources/CollectionApi.cs
+++ b/src/Kyoo.Core/Views/Resources/CollectionApi.cs
@@ -34,8 +34,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// Information about one or multiple <see cref="Collection"/>.
 	/// </summary>
-	[Route("api/collections")]
-	[Route("api/collection", Order = AlternativeRoute)]
+	[Route("collections")]
+	[Route("collection", Order = AlternativeRoute)]
 	[ApiController]
 	[PartialPermission(nameof(Collection))]
 	[ApiDefinition("Collections", Group = ResourcesGroup)]

--- a/src/Kyoo.Core/Views/Resources/EpisodeApi.cs
+++ b/src/Kyoo.Core/Views/Resources/EpisodeApi.cs
@@ -34,8 +34,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// Information about one or multiple <see cref="Episode"/>.
 	/// </summary>
-	[Route("api/episodes")]
-	[Route("api/episode", Order = AlternativeRoute)]
+	[Route("episodes")]
+	[Route("episode", Order = AlternativeRoute)]
 	[ApiController]
 	[ResourceView]
 	[PartialPermission(nameof(Episode))]

--- a/src/Kyoo.Core/Views/Resources/LibraryApi.cs
+++ b/src/Kyoo.Core/Views/Resources/LibraryApi.cs
@@ -36,8 +36,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// Information about one or multiple <see cref="Library"/>.
 	/// </summary>
-	[Route("api/libraries")]
-	[Route("api/library", Order = AlternativeRoute)]
+	[Route("libraries")]
+	[Route("library", Order = AlternativeRoute)]
 	[ApiController]
 	[ResourceView]
 	[PartialPermission(nameof(Library), Group = Group.Admin)]

--- a/src/Kyoo.Core/Views/Resources/LibraryItemApi.cs
+++ b/src/Kyoo.Core/Views/Resources/LibraryItemApi.cs
@@ -34,8 +34,8 @@ namespace Kyoo.Core.Api
 	/// Endpoint for items that are not part of a specific library.
 	/// An item can ether represent a collection or a show.
 	/// </summary>
-	[Route("api/items")]
-	[Route("api/item", Order = AlternativeRoute)]
+	[Route("items")]
+	[Route("item", Order = AlternativeRoute)]
 	[ApiController]
 	[ResourceView]
 	[PartialPermission(nameof(LibraryItem))]

--- a/src/Kyoo.Core/Views/Resources/SearchApi.cs
+++ b/src/Kyoo.Core/Views/Resources/SearchApi.cs
@@ -32,7 +32,7 @@ namespace Kyoo.Core.Api
 	/// An endpoint to search for every resources of kyoo. Searching for only a specific type of resource
 	/// is available on the said endpoint.
 	/// </summary>
-	[Route("api/search/{query}")]
+	[Route("search/{query}")]
 	[ApiController]
 	[ResourceView]
 	[ApiDefinition("Search", Group = ResourcesGroup)]

--- a/src/Kyoo.Core/Views/Resources/SeasonApi.cs
+++ b/src/Kyoo.Core/Views/Resources/SeasonApi.cs
@@ -34,8 +34,8 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// Information about one or multiple <see cref="Season"/>.
 	/// </summary>
-	[Route("api/seasons")]
-	[Route("api/season", Order = AlternativeRoute)]
+	[Route("seasons")]
+	[Route("season", Order = AlternativeRoute)]
 	[ApiController]
 	[PartialPermission(nameof(Season))]
 	[ApiDefinition("Seasons", Group = ResourcesGroup)]

--- a/src/Kyoo.Core/Views/Resources/ShowApi.cs
+++ b/src/Kyoo.Core/Views/Resources/ShowApi.cs
@@ -36,10 +36,10 @@ namespace Kyoo.Core.Api
 	/// <summary>
 	/// Information about one or multiple <see cref="Show"/>.
 	/// </summary>
-	[Route("api/shows")]
-	[Route("api/show", Order = AlternativeRoute)]
-	[Route("api/movie", Order = AlternativeRoute)]
-	[Route("api/movies", Order = AlternativeRoute)]
+	[Route("shows")]
+	[Route("show", Order = AlternativeRoute)]
+	[Route("movie", Order = AlternativeRoute)]
+	[Route("movies", Order = AlternativeRoute)]
 	[ApiController]
 	[PartialPermission(nameof(Show))]
 	[ApiDefinition("Shows", Group = ResourcesGroup)]

--- a/src/Kyoo.Core/Views/Watch/TrackApi.cs
+++ b/src/Kyoo.Core/Views/Watch/TrackApi.cs
@@ -32,8 +32,8 @@ namespace Kyoo.Core.Api
 	/// Information about one or multiple <see cref="Track"/>.
 	/// A track contain metadata about a video, an audio or a subtitles.
 	/// </summary>
-	[Route("api/tracks")]
-	[Route("api/track", Order = AlternativeRoute)]
+	[Route("tracks")]
+	[Route("track", Order = AlternativeRoute)]
 	[ApiController]
 	[ResourceView]
 	[PartialPermission(nameof(Track))]

--- a/src/Kyoo.Core/Views/Watch/WatchApi.cs
+++ b/src/Kyoo.Core/Views/Watch/WatchApi.cs
@@ -34,8 +34,8 @@ namespace Kyoo.Core.Api
 	/// It contains streams (video, audio, subtitles) information, chapters, next and previous episodes and a bit of
 	/// information of the show.
 	/// </summary>
-	[Route("api/watch")]
-	[Route("api/watchitem", Order = AlternativeRoute)]
+	[Route("watch")]
+	[Route("watchitem", Order = AlternativeRoute)]
 	[ApiController]
 	[ApiDefinition("Watch Items", Group = WatchGroup)]
 	public class WatchApi : ControllerBase

--- a/src/Kyoo.Host.Generic/settings.json
+++ b/src/Kyoo.Host.Generic/settings.json
@@ -1,7 +1,6 @@
 {
   "basics": {
     "url": "http://*:5000",
-    "publicUrl": "http://localhost:5000/",
     "pluginsPath": "plugins/",
     "transmuxPath": "cached/transmux",
     "transcodePath": "cached/transcode",

--- a/src/Kyoo.Host.WindowsTrait/SystemTrait.cs
+++ b/src/Kyoo.Host.WindowsTrait/SystemTrait.cs
@@ -40,7 +40,7 @@ namespace Kyoo.Host.WindowsTrait
 		private readonly IApplication _application;
 
 		/// <summary>
-		/// The options containing the <see cref="BasicOptions.PublicUrl"/>.
+		/// The options containing the <see cref="BasicOptions.Url"/>.
 		/// </summary>
 		private readonly IOptions<BasicOptions> _options;
 
@@ -90,7 +90,7 @@ namespace Kyoo.Host.WindowsTrait
 			private readonly IApplication _application;
 
 			/// <summary>
-			/// The options containing the <see cref="BasicOptions.PublicUrl"/>.
+			/// The options containing the <see cref="BasicOptions.Url"/>.
 			/// </summary>
 			private readonly IOptions<BasicOptions> _options;
 
@@ -161,7 +161,7 @@ namespace Kyoo.Host.WindowsTrait
 			{
 				Process browser = new()
 				{
-					StartInfo = new ProcessStartInfo(_options.Value.PublicUrl.ToString())
+					StartInfo = new ProcessStartInfo(_options.Value.Url.ToString().Replace("//*:", "//localhost:"))
 					{
 						UseShellExecute = true
 					}

--- a/src/Kyoo.Swagger/SwaggerModule.cs
+++ b/src/Kyoo.Swagger/SwaggerModule.cs
@@ -91,11 +91,6 @@ namespace Kyoo.Swagger
 						Name = "GPL-3.0-or-later",
 						Url = "https://github.com/AnonymusRaccoon/Kyoo/blob/master/LICENSE"
 					};
-					options.Servers.Add(new OpenApiServer
-					{
-						Url = _configuration.GetPublicUrl().ToString(),
-						Description = "The currently running kyoo's instance."
-					});
 
 					options.Info.ExtensionData ??= new Dictionary<string, object>();
 					options.Info.ExtensionData["x-logo"] = new

--- a/tests/robot/rest.resource
+++ b/tests/robot/rest.resource
@@ -1,4 +1,4 @@
 *** Settings ***
 Documentation       Common things to handle rest requests
 
-Library             REST    http://localhost:5000/api
+Library             REST    http://localhost:5000


### PR DESCRIPTION
Warning: This is a breaking change.

This removes the /api from the API URL (as front and back will not be on the same port), a follow-up PR would be needed for that.
This removes the public URL from the returned Uris.