### PR TITLE
fix(front): update initial state api url

### DIFF
--- a/front/src/ui/login/login.tsx
+++ b/front/src/ui/login/login.tsx
@@ -11,7 +11,7 @@ import { PasswordInput } from "./password-input";
 import { ServerUrlPage } from "./server-url";
 
 export const LoginPage = () => {
-	const [apiUrl] = useQueryState("apiUrl", null);
+	const [apiUrl] = useQueryState("apiUrl", "");
 	const [username, setUsername] = useState("");
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState<string | undefined>();

--- a/front/src/ui/login/register.tsx
+++ b/front/src/ui/login/register.tsx
@@ -11,7 +11,7 @@ import { PasswordInput } from "./password-input";
 import { ServerUrlPage } from "./server-url";
 
 export const RegisterPage = () => {
-	const [apiUrl] = useQueryState("apiUrl", null);
+	const [apiUrl] = useQueryState("apiUrl", "");
 	const [email, setEmail] = useState("");
 	const [username, setUsername] = useState("");
 	const [password, setPassword] = useState("");


### PR DESCRIPTION
This prevents URLs like this `https://kyoo.domain.tld/login?apiUrl=null` which would cause requests to `https://kyoo.domain.tld/null/auth/users` resulting in a 405 error from nginx.