### PR TITLE
fix(api): don't crash if not superuser

### DIFF
--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -116,13 +116,17 @@ export const db = drizzle({
 });
 
 export const migrate = async () => {
-	await db.execute(
-		sql.raw(`
+	try {
+		await db.execute(
+			sql.raw(`
 			create extension if not exists pg_trgm;
 			SET pg_trgm.word_similarity_threshold = 0.4;
 			ALTER DATABASE "${postgresConfig.database}" SET pg_trgm.word_similarity_threshold = 0.4;
 		`),
-	);
+		);
+	} catch (err: any) {
+		console.error("Error while updating pg_trgm", err.message);
+	}
 	await migrateDb(db, {
 		migrationsSchema: "kyoo",
 		migrationsFolder: "./drizzle",


### PR DESCRIPTION
While testing kyoo v5, I was unable to launch the api because of this query which requires superuser rights (owner of the db is not enough):
`ALTER DATABASE "${postgresConfig.database}" SET pg_trgm.word_similarity_threshold = 0.4;`

I believe Kyoo should be usable without superuser rights so I added a try/catch as a quickfix to only display an error on startup.