### PR TITLE
feat(auth): update forward auth endpoint

### DIFF
--- a/auth/main.go
+++ b/auth/main.go
@@ -19,10 +19,10 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
-	"github.com/labstack/echo-jwt/v4"
+	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/swaggo/echo-swagger"
+	echoSwagger "github.com/swaggo/echo-swagger"
 )
 
 func ErrorHandler(err error, c echo.Context) {
@@ -248,6 +248,7 @@ func main() {
 	r.DELETE("/keys/:id", h.DeleteApiKey)
 
 	g.GET("/jwt", h.CreateJwt)
+	g.Any("/jwt/*", h.CreateJwt)
 	e.GET("/.well-known/jwks.json", h.GetJwks)
 	e.GET("/.well-known/openid-configuration", h.GetOidcConfig)
 

--- a/auth/tests/externalauth-apikey.hurl
+++ b/auth/tests/externalauth-apikey.hurl
@@ -1,0 +1,36 @@
+POST {{host}}/keys
+# this is created from the gh workflow file's env var
+X-API-KEY: hurl-1234apikey
+{
+	"name": "dryflower",
+	"claims": {
+		"isAdmin": true,
+		"permissions": ["apikeys.read"]
+	}
+}
+HTTP 201
+[Captures]
+id: jsonpath "$.id"
+token: jsonpath "$.token"
+
+# Check external auth with api key
+GET {{host}}/jwt
+X-API-KEY: {{token}}
+HTTP 200
+[Captures]
+auth_header_apikey: header "Authorization"
+
+# Check if the auth header is working
+GET {{host}}/keys
+Authorization: {{auth_header_apikey}}
+HTTP 200
+[Asserts]
+jsonpath "$.items[0].id" == {{id}}
+jsonpath "$.items[0].name" == "dryflower"
+jsonpath "$.items[0].claims.permissions" contains "apikeys.read"
+
+# Clean api key
+
+DELETE {{host}}/keys/{{id}}
+X-API-KEY: hurl-1234apikey
+HTTP 200

--- a/auth/tests/externalauth-user.hurl
+++ b/auth/tests/externalauth-user.hurl
@@ -1,0 +1,41 @@
+POST {{host}}/users
+{
+    "username": "user-1",
+    "password": "password-user-1",
+    "email": "user-1@zoriya.dev"
+}
+HTTP 201
+[Captures]
+token: jsonpath "$.token"
+
+# Check external auth with token
+
+POST {{host}}/jwt/api/movies
+Authorization: Bearer {{token}}
+HTTP 200
+[Captures]
+auth_header_token: header "Authorization"
+
+# Check if the auth header is working
+GET {{host}}/users/me
+Authorization: {{auth_header_token}}
+HTTP 200
+
+# Check external auth with cookie
+
+DELETE {{host}}/jwt/toto
+Cookie: X-Bearer={{token}}
+HTTP 200
+[Captures]
+auth_header_cookie: header "Authorization"
+
+# Check if the auth header is working
+GET {{host}}/users/me
+Authorization: {{auth_header_cookie}}
+HTTP 200
+
+# Clean user
+
+DELETE {{host}}/users/me
+Authorization: Bearer {{token}}
+HTTP 200


### PR DESCRIPTION
Why this change?

In my tests with Envoy, the [ext_authz](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto) filter used for external authorization doesn't directly call the `/auth/jwt` endpoint, but adds a prefix to the queried path, resulting in a middleware call like this: `GET /auth/jwt/api/movies`. Furthermore, the HTTP method is preserved.

The GEP-1494, mentionned by @acelinkio in https://github.com/zoriya/Kyoo/issues/968#issuecomment-3482350025, established an API based on the behavior of the ext_authz filter (https://gateway-api.sigs.k8s.io/geps/gep-1494/#why-envoys-ext_authz) so IMO Kyoo should handle this behavior.

I also added Hurl tests to test cookie handling.
