### PR TITLE
kyoo_api logs redact password & other sensitive fields

### DIFF
--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -126,7 +126,7 @@ console.log("Connecting to postgres with config", {
 					cert: "<redacted>",
 					ca: "<redacted>",
 				}
-				: postgresConfig.ssl,
+			: postgresConfig.ssl,
 });
 export const db = drizzle({
 	schema,


### PR DESCRIPTION
Currently the kyoo_api logs the following on startup--where it bleeds the password field
```log
Connecting to postgres with config {
  connectionString: undefined,
  host: "kyoo-postgres",
  port: 5432,
  database: "kyoo_api",
  user: "kyoo_all",
  password: "watchSomething4me",
  options: undefined,
  application_name: "kyoo",
}
```

following this change
```log
Connecting to postgres with config {
  connectionString: undefined,
  host: "kyoo-postgres",
  port: 5432,
  database: "kyoo_api",
  user: "kyoo_all",
  password: "<redacted>",
  options: undefined,
  application_name: "kyoo",
  ssl: false,
}
```

