### PR TITLE
kyoo_api extension install specify schema 

### DIFF
--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -128,8 +128,6 @@ export const migrate = record("migrate", async () => {
 		await db.execute(
 			sql.raw(`
 				create schema if not exists ${APP_SCHEMA};
-				alter database "${postgresConfig.database}" set search_path = ${APP_SCHEMA}, public;
-				set search_path = ${APP_SCHEMA}, public;
 				create extension if not exists pg_trgm schema ${APP_SCHEMA};
 				set pg_trgm.word_similarity_threshold = 0.4;
 				alter database "${postgresConfig.database}" set pg_trgm.word_similarity_threshold = 0.4;


### PR DESCRIPTION
explicitly specify schema for extension install rather than rely upon implicit

https://www.postgresql.org/docs/current/sql-createextension.html
> schema_name
    The name of the schema in which to install the extension's objects, given that the extension allows its contents to be relocated. The named schema must already exist. If not specified, and the extension's control file does not specify a schema either, the current default object creation schema is used.


