### PR TITLE
downgrade cloudpirates postgres 0.12.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,4 +12,4 @@ dependencies:
 - condition: postgres.enabled
   name: postgres
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 0.12.1
+  version: 0.12.0


### PR DESCRIPTION
there is a bug with the 0.12.1 release of postgres.  will be resolved in https://github.com/CloudPirates-io/helm-charts/pull/674

in the next version, we'll need to update to 0.12.3 and change the password key as in: https://github.com/zoriya/Kyoo/pull/1186