### PR TITLE
feat(chart): add ResourceClaimTemplates support for DRA

### DIFF
--- a/chart/templates/api/deployment.yaml
+++ b/chart/templates/api/deployment.yaml
@@ -34,6 +34,13 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.api.resourceClaims }}
+      resourceClaims:
+        {{- range . }}
+        - name: {{ .name }}
+          resourceClaimTemplateName: {{ .resourceClaimTemplateName }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.api.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/auth/deployment.yaml
+++ b/chart/templates/auth/deployment.yaml
@@ -34,6 +34,13 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.auth.resourceClaims }}
+      resourceClaims:
+        {{- range . }}
+        - name: {{ .name }}
+          resourceClaimTemplateName: {{ .resourceClaimTemplateName }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.auth.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/front/deployment.yaml
+++ b/chart/templates/front/deployment.yaml
@@ -34,6 +34,13 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.front.resourceClaims }}
+      resourceClaims:
+        {{- range . }}
+        - name: {{ .name }}
+          resourceClaimTemplateName: {{ .resourceClaimTemplateName }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.front.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -34,6 +34,13 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.scanner.resourceClaims }}
+      resourceClaims:
+        {{- range . }}
+        - name: {{ .name }}
+          resourceClaimTemplateName: {{ .resourceClaimTemplateName }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.scanner.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -37,6 +37,13 @@ spec:
       {{- with .Values.transcoder.runtimeClass }}
       runtimeClassName: {{ . }}
       {{- end }}
+      {{- with .Values.transcoder.resourceClaims }}
+      resourceClaims:
+        {{- range . }}
+        - name: {{ .name }}
+          resourceClaimTemplateName: {{ .resourceClaimTemplateName }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.transcoder.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -219,6 +219,9 @@ api:
   extraContainers: []
   extraInitContainers: []
   extraVolumes: []
+  # resourceClaims for Dynamic Resource Allocation (DRA)
+  # useful for accessing hardware resources via ResourceClaimTemplates (Kubernetes 1.34+)
+  resourceClaims: []
   # api image data
   # user profile pictures
   persistence:
@@ -269,6 +272,9 @@ auth:
   extraContainers: []
   extraInitContainers: []
   extraVolumes: []
+  # resourceClaims for Dynamic Resource Allocation (DRA)
+  # useful for accessing hardware resources via ResourceClaimTemplates (Kubernetes 1.34+)
+  resourceClaims: []
 
 # front deployment configuration
 front:
@@ -303,6 +309,9 @@ front:
   extraContainers: []
   extraInitContainers: []
   extraVolumes: []
+  # resourceClaims for Dynamic Resource Allocation (DRA)
+  # useful for accessing hardware resources via ResourceClaimTemplates (Kubernetes 1.34+)
+  resourceClaims: []
 
 # scanner deployment configuration
 scanner:
@@ -344,12 +353,25 @@ scanner:
   extraContainers: []
   extraInitContainers: []
   extraVolumes: []
+  # resourceClaims for Dynamic Resource Allocation (DRA)
+  # useful for accessing hardware resources via ResourceClaimTemplates (Kubernetes 1.34+)
+  resourceClaims: []
 
-# scanner deployment configuration
+# transcoder deployment configuration
 transcoder:
   name: transcoder
   # can be used if you have a gpu runtime class
   runtimeClass: ""
+  # resourceClaims for Dynamic Resource Allocation (DRA)
+  # useful for GPU access via ResourceClaimTemplates (Kubernetes 1.34+)
+  # example:
+  #   resourceClaims:
+  #     - name: gpu
+  #       resourceClaimTemplateName: gpu-claim-template
+  # then reference in kyoo_transcoder.resources:
+  #   claims:
+  #     - name: gpu
+  resourceClaims: []
   # kyoo_transcoder container configuration
   kyoo_transcoder:
     livenessProbe:


### PR DESCRIPTION
## Summary

- Add `resourceClaims` configuration to all deployment templates to support Kubernetes Dynamic Resource Allocation (DRA) with ResourceClaimTemplates (GA in Kubernetes 1.34+)
- Particularly useful for the transcoder component to access GPU resources through DRA instead of traditional device plugins

## Example Usage

```yaml
transcoder:
  resourceClaims:
    - name: gpu
      resourceClaimTemplateName: gpu-claim-template
  kyoo_transcoder:
    resources:
      claims:
        - name: gpu
```

Closes #1172