### PR TITLE
fix: add cache scope to prevent multi-platform build collisions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,8 +107,8 @@ jobs:
             VERSION=0.0.0
           push: ${{env.SHOULD_PUSH}}
           tags: ${{steps.meta.outputs.tags}}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.label }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.label }}
 
       - name: Sync README.MD
         if: env.SHOULD_PUSH == 'true' && env.DOCKERHUB_ENABLED == 'true'


### PR DESCRIPTION
Add scope parameter to GHA cache configuration to ensure each image (api, front, scanner, transcoder, auth) gets its own cache namespace. This prevents cache collisions that were causing arm64 builds to fail for kyoo_auth images.