### PR TITLE
api: add logger to show log output during tests

### DIFF
--- a/api/tests/manual.ts
+++ b/api/tests/manual.ts
@@ -1,6 +1,7 @@
 import { db, migrate } from "~/db";
 import { profiles, shows } from "~/db/schema";
 import { bubble, madeInAbyss } from "~/models/examples";
+import { setupLogging } from "../src/logtape";
 import { createMovie, createSerie, createVideo, getVideos } from "./helpers";
 
 // test file used to run manually using `bun tests/manual.ts`
@@ -8,6 +9,7 @@ import { createMovie, createSerie, createVideo, getVideos } from "./helpers";
 // export JWT_SECRET="this is a secret";
 // export JWT_ISSUER="https://kyoo.zoriya.dev";
 
+await setupLogging();
 await migrate();
 await db.delete(shows);
 await db.delete(profiles);

--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -1,4 +1,7 @@
 import { beforeAll } from "bun:test";
+import { setupLogging } from "../src/logtape";
+
+await setupLogging();
 
 process.env.PGDATABASE = "kyoo_test";
 process.env.JWT_SECRET = "this is a secret";


### PR DESCRIPTION
Adds in logetape loggger during testing.  Log messages will show up 

```log
bun tests/manual.ts
03:32:56.901 INF  Connecting to postgres with {
  connectionString: undefined,
  host: "kyoo-dev-postgres",
  port: 5432,
  database: "kyoo_api",
  user: "kyoo_all",
  password: "[REDACTED]",
  options: undefined,
  application_name: "kyoo.api",
  ssl: false,
}
03:32:56.903 INF  Setting up database
03:32:57.001 INF  Database kyoo_api migrated
DataError: Data provided to an operation does not meet requirements
DOMException {
  line: 1,
...
```

```log
bun test
bun test v1.3.5 (1e86cebd)

tests/videos/getdel.test.ts:
03:32:30.749 INF  Connecting to postgres with {
  connectionString: undefined,
  host: "kyoo-dev-postgres",
  port: 5432,
  database: "kyoo_api",
  user: "kyoo_all",
  password: "[REDACTED]",
  options: undefined,
  application_name: "kyoo.api",
  ssl: false,
}
03:32:30.752 INF  Setting up database
03:32:30.845 INF  Database kyoo_api migrated
✓ Video get/deletion > Get current state [42.24ms]
✓ Video get/deletion > With unknown [41.71ms]
✓ Video get/deletion > Mismatch title guess [82.12ms]
...
```