### PR TITLE
auth/transcoder: associates the echo logs with request context

### DIFF
--- a/auth/main.go
+++ b/auth/main.go
@@ -272,8 +272,9 @@ func main() {
 		LogUserAgent: true,
 		HandleError:  true, // forwards error to the global error handler, so it can decide appropriate status code
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+			rCtx := c.Request().Context()
 			if v.Error == nil {
-				logger.LogAttrs(ctx, slog.LevelInfo, "web_request",
+				logger.LogAttrs(rCtx, slog.LevelInfo, "web_request",
 					slog.String("method", v.Method),
 					slog.Int("status", v.Status),
 					slog.String("host", v.Host),
@@ -281,7 +282,7 @@ func main() {
 					slog.String("agent", v.UserAgent),
 				)
 			} else {
-				logger.LogAttrs(ctx, slog.LevelError, "web_request_error",
+				logger.LogAttrs(rCtx, slog.LevelError, "web_request_error",
 					slog.String("method", v.Method),
 					slog.Int("status", v.Status),
 					slog.String("host", v.Host),

--- a/transcoder/main.go
+++ b/transcoder/main.go
@@ -132,8 +132,9 @@ func main() {
 		LogUserAgent: true,
 		HandleError:  true, // forwards error to the global error handler, so it can decide appropriate status code
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+			rCtx := c.Request().Context()
 			if v.Error == nil {
-				logger.LogAttrs(ctx, slog.LevelInfo, "web_request",
+				logger.LogAttrs(rCtx, slog.LevelInfo, "web_request",
 					slog.String("method", v.Method),
 					slog.Int("status", v.Status),
 					slog.String("host", v.Host),
@@ -141,7 +142,7 @@ func main() {
 					slog.String("agent", v.UserAgent),
 				)
 			} else {
-				logger.LogAttrs(ctx, slog.LevelError, "web_request_error",
+				logger.LogAttrs(rCtx, slog.LevelError, "web_request_error",
 					slog.String("method", v.Method),
 					slog.Int("status", v.Status),
 					slog.String("host", v.Host),


### PR DESCRIPTION
Logs should have their http request context from echo.  This allows for the related echo logs to be associated with the trace generated from that request.