### PR TITLE
auth/transcoder: fix tripple responses on errors

### DIFF
--- a/auth/main.go
+++ b/auth/main.go
@@ -31,6 +31,12 @@ import (
 )
 
 func ErrorHandler(err error, c echo.Context) {
+	// otelecho & RequestLoggerWithConfig middleware call c.Error
+	// otelecho docs: https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho#WithOnError
+	if c.Response().Committed {
+		return
+	}
+
 	code := http.StatusInternalServerError
 	var message string
 

--- a/transcoder/main.go
+++ b/transcoder/main.go
@@ -27,6 +27,12 @@ import (
 )
 
 func ErrorHandler(err error, c echo.Context) {
+	// otelecho & RequestLoggerWithConfig middleware call c.Error
+	// otelecho docs: https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho#WithOnError
+	if c.Response().Committed {
+		return
+	}
+
 	code := http.StatusInternalServerError
 	var message string
 	if he, ok := err.(*echo.HTTPError); ok {


### PR DESCRIPTION
without this fix, any errors triggered create multiple responses sent to the client.

# examples
**kyoo_auth**
```log
curl https://kyoo-dev.bitey.life/auth/failme
{"status":404,"message":"Not Found","details":null}
{"status":404,"message":"Not Found","details":null}
{"status":404,"message":"Not Found","details":null}
```

**kyoo_transcoder**
```log
root@kyoo-dev-transcoder-devspace-cdb5b6c79-6lrcn:/app# curl localhost:7666/test123
{"errors":["Not Found"]}
{"errors":["Not Found"]}
{"errors":["Not Found"]}
```

## Root Cause

This is caused by how Echo's middleware architecture handles errors. When a handler returns an error:

1. The handler returns an error
2. `RequestLoggerWithConfig` (with `HandleError: true`) intercepts it, logs the request, then re-returns the error, which invokes `HTTPErrorHandler`
3. `otelecho` middleware intercepts it and calls `c.Error(err)` to capture response data for the tracing span, which invokes `HTTPErrorHandler` again
4. Echo's main `ServeHTTP` then calls `HTTPErrorHandler` a third time after all middleware completes
5. Each call to `HTTPErrorHandler` writes a response to the client before the response is committed


We might be able to turn RequestLoggerWithConfig `HandleError` to `false`.  But otelecho uses the return for updating span information and acknowledges it inside of their docs.

otelecho docs: https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho#WithOnError 
otelecho PR: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/8025


This fix ensures only the first invocation actually sends a response to the client, while subsequent invocations (from middleware) are no-ops.
