### PR TITLE
api: fix tracing

### DIFF
--- a/api/src/otel.ts
+++ b/api/src/otel.ts
@@ -124,7 +124,6 @@ export function setupOtel() {
 	logapi.setGlobalLoggerProvider(lp);
 	metricapi.setGlobalMeterProvider(mp);
 	tp.register();
-	traceapi.setGlobalTracerProvider(tp);
 }
 
 export function record<T extends (...args: any) => any>(


### PR DESCRIPTION
Adding tp.register() fixes the missing methods / path from showing.

<img width="1188" height="506" alt="image" src="https://github.com/user-attachments/assets/92c5d038-f9be-46d0-97de-e9f5d9ef72cd" />

i thought that setGloabl calls would handle registering.  the javascript otel docs are a bit lacking--esepcially compared to golang.
```ts
	logapi.setGlobalLoggerProvider(lp);
	metricapi.setGlobalMeterProvider(mp);
	tp.register();
	traceapi.setGlobalTracerProvider(tp);
```