### PR TITLE
auth: return 403 when no GUEST_CLAIMS configured

### DIFF
--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -66,6 +66,9 @@ func (h *Handler) CreateJwt(c echo.Context) error {
 	var jwt *string
 	if token == "" {
 		jwt = h.createGuestJwt()
+		if jwt == nil {
+			return echo.NewHTTPError(http.StatusUnauthorized, "Guests not allowed.")
+		}
 	} else {
 		tkn, err := h.createJwt(ctx, token)
 		if err != nil {

--- a/auth/main.go
+++ b/auth/main.go
@@ -191,6 +191,9 @@ func (h *Handler) TokenToJwt(next echo.HandlerFunc) echo.HandlerFunc {
 
 			if auth == "" || !strings.HasPrefix(auth, "Bearer ") {
 				jwt = h.createGuestJwt()
+				if jwt == nil {
+					return echo.NewHTTPError(http.StatusUnauthorized, "Guests not allowed.")
+				}
 			} else {
 				token := auth[len("Bearer "):]
 				// this is only used to check if it is a session token or a jwt


### PR DESCRIPTION
When no guest claims are configured, auth server should return 403s.  

Returning 200s will bypass the forwardAuth and have the request continue to the backend.

