### PR TITLE
env.sample: Do not set otel_exporter by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,8 @@ KEIBI_APIKEY_SCANNER_CLAIMS='{"permissions": ["core.read", "core.write"]}'
 # To debug the front end, you can set the following to an external backend
 KYOO_URL=
 
-OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
-OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+#OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+#OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 
 # It is recommended to use the below PG environment variables when possible.
 # POSTGRES_URL=postgres://user:password@hostname:port/dbname?sslmode=verify-full&sslrootcert=/path/to/server.crt&sslcert=/path/to/client.crt&sslkey=/path/to/client.key


### PR DESCRIPTION
Do not set OTEL_EXPORTER by default on the .env.sample. Was trying to do a test deployment and while some services were coming up I was getting a ton of connection errors and turns out it was trying to connect to a telemetry server that doesnt exist since it was set by default on the env sample.