### PR TITLE
Add expose docker instruction

### DIFF
--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -10,5 +10,5 @@ RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY . .
-
+EXPOSE 4389
 CMD ["fastapi", "run", "scanner", "--port", "4389"]


### PR DESCRIPTION
Without this instruction, traefik doesn't know which port to use on macos.