### PR TITLE
Fix deadlock on transcoder

### DIFF
--- a/transcoder/src/keyframes.go
+++ b/transcoder/src/keyframes.go
@@ -29,7 +29,7 @@ type Keyframe struct {
 type KeyframeInfo struct {
 	ready     sync.WaitGroup
 	mutex     sync.RWMutex
-	listeners []func(keyframes []float64)
+	listeners []func(keyframesLen int)
 }
 
 func (kf *Keyframe) Get(idx int32) float64 {
@@ -63,14 +63,16 @@ func (kf *Keyframe) Length() (int32, bool) {
 
 func (kf *Keyframe) add(values []float64) {
 	kf.info.mutex.Lock()
-	defer kf.info.mutex.Unlock()
 	kf.Keyframes = append(kf.Keyframes, values...)
+	newLen := len(kf.Keyframes)
+	kf.info.mutex.Unlock()
+
 	for _, listener := range kf.info.listeners {
-		listener(kf.Keyframes)
+		listener(newLen)
 	}
 }
 
-func (kf *Keyframe) AddListener(callback func(keyframes []float64)) {
+func (kf *Keyframe) AddListener(callback func(keyframesLen int)) {
 	kf.info.mutex.Lock()
 	defer kf.info.mutex.Unlock()
 	kf.info.listeners = append(kf.info.listeners, callback)

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -84,16 +84,16 @@ func NewStream(file *FileStream, keyframes *Keyframe, handle StreamHandle, ret *
 		}
 
 		if !is_done {
-			keyframes.AddListener(func(keyframes []float64) {
+			keyframes.AddListener(func(keyframesLen int) {
 				ret.lock.Lock()
 				defer ret.lock.Unlock()
 				old_length := len(ret.segments)
-				if cap(ret.segments) > len(keyframes) {
-					ret.segments = ret.segments[:len(keyframes)]
+				if cap(ret.segments) > keyframesLen {
+					ret.segments = ret.segments[:keyframesLen]
 				} else {
-					ret.segments = append(ret.segments, make([]Segment, len(keyframes)-old_length)...)
+					ret.segments = append(ret.segments, make([]Segment, keyframesLen-old_length)...)
 				}
-				for seg := old_length; seg < len(keyframes); seg++ {
+				for seg := old_length; seg < keyframesLen; seg++ {
 					ret.segments[seg].channel = make(chan struct{})
 				}
 			})


### PR DESCRIPTION
There was a deadlock when cleanup was started while keyframe analysis was running and notified a stream.