### PR TITLE
Fix transcoder tracker hang

### DIFF
--- a/transcoder/src/filestream.go
+++ b/transcoder/src/filestream.go
@@ -65,16 +65,33 @@ func (t *Transcoder) newFileStream(ctx context.Context, path string, sha string)
 }
 
 func (fs *FileStream) Kill() {
-	fs.videos.lock.Lock()
-	defer fs.videos.lock.Unlock()
-	fs.audios.lock.Lock()
-	defer fs.audios.lock.Unlock()
-
+	// Snapshot the substreams under a brief read lock, then kill them outside the
+	// lock. Killing acquires each substream's head lock, which can be contended;
+	// holding the CMap write locks across those calls would block concurrent
+	// stream creation (GetOrCreate) and status snapshots on this file.
+	fs.videos.lock.RLock()
+	videos := make([]*VideoStream, 0, len(fs.videos.data))
 	for _, s := range fs.videos.data {
-		s.Kill()
+		videos = append(videos, s)
 	}
+	fs.videos.lock.RUnlock()
+
+	fs.audios.lock.RLock()
+	audios := make([]*AudioStream, 0, len(fs.audios.data))
 	for _, s := range fs.audios.data {
-		s.Kill()
+		audios = append(audios, s)
+	}
+	fs.audios.lock.RUnlock()
+
+	for _, s := range videos {
+		if s != nil {
+			s.Kill()
+		}
+	}
+	for _, s := range audios {
+		if s != nil {
+			s.Kill()
+		}
 	}
 }
 

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -114,18 +114,6 @@ func NewStream(ctx context.Context, file *FileStream, keyframes *Keyframe, handl
 			})
 		}
 		ret.ready.Done()
-
-		// Eagerly start a transcode from the beginning. This optimizes the common
-		// "play from the start" path (segments and the shared init segment are
-		// produced before the client asks for them)
-		if length > 0 {
-			go func() {
-				err := ret.run(ctx, 0)
-				if err != nil {
-					slog.WarnContext(ctx, "warmup transcode failed", "path", ret.file.Info.Path, "err", err)
-				}
-			}()
-		}
 	}()
 }
 
@@ -528,12 +516,16 @@ func (ts *Stream) finalizeSegment(path string, startSegment int32) error {
 
 func (ts *Stream) GetInit(ctx context.Context) (string, error) {
 	ctx = context.WithoutCancel(ctx)
-	if _, err := ts.GetSegment(ctx, 0); err != nil {
-		return "", err
-	}
 	encoder := ts.initEncoderId.Load()
 	if encoder == -1 {
-		return "", fmt.Errorf("init segment not ready yet")
+		// not init.mp4 ready, start transcode at 0 it should generate an init
+		if _, err := ts.GetSegment(ctx, 0); err != nil {
+			return "", err
+		}
+		encoder = ts.initEncoderId.Load()
+		if encoder == -1 {
+			return "", fmt.Errorf("init segment not ready yet")
+		}
 	}
 	return ts.handle.getInitPath(int(encoder)), nil
 }

--- a/transcoder/src/tracker.go
+++ b/transcoder/src/tracker.go
@@ -67,6 +67,17 @@ func (t *Tracker) start() {
 	inactive_time := 1 * time.Hour
 	timer := time.After(inactive_time)
 	for {
+		// Serve pending snapshots first so /streams stays responsive even when
+		// clientChan is flooded (a burst of index.m3u8/segment requests). Without
+		// this, select picks between the ready cases uniformly at random and the
+		// snapshot can be starved for the whole burst.
+		select {
+		case reply := <-t.snapshotReq:
+			reply <- t.cloneClients()
+			continue
+		default:
+		}
+
 		select {
 		case info, ok := <-t.transcoder.clientChan:
 			if !ok {
@@ -163,7 +174,7 @@ func (t *Tracker) KillStreamIfDead(sha string, path string) bool {
 	if !ok {
 		return false
 	}
-	stream.Kill()
+	go stream.Kill()
 	go func() {
 		time.Sleep(4 * time.Hour)
 		t.deletedStream <- sha
@@ -183,7 +194,7 @@ func (t *Tracker) DestroyStreamIfOld(sha string) {
 	if !ok {
 		return
 	}
-	stream.Destroy(context.WithoutCancel(context.Background()))
+	go stream.Destroy(context.WithoutCancel(context.Background()))
 }
 
 func (t *Tracker) KillAudioIfDead(sha string, path string, audio AudioKey) bool {
@@ -203,7 +214,7 @@ func (t *Tracker) KillAudioIfDead(sha string, path string, audio AudioKey) bool 
 	if !aok {
 		return false
 	}
-	astream.Kill()
+	go astream.Kill()
 	return true
 }
 
@@ -224,31 +235,41 @@ func (t *Tracker) KillVideoIfDead(sha string, path string, video VideoKey) bool 
 	if !vok {
 		return false
 	}
-	vstream.Kill()
+	go vstream.Kill()
 	return true
 }
 
 func (t *Tracker) KillOrphanedHeads(sha string, video *VideoKey, audio *AudioKey) {
-	stream, ok := t.transcoder.streams.Get(sha)
-	if !ok {
-		return
+	// Snapshot the viewer head positions while we are on the tracker goroutine
+	// (the only writer of t.clients). The lock-heavy part - acquiring each
+	// stream's head lock - is then dispatched so it can't stall the loop.
+	vheads := make([]int32, 0, len(t.clients))
+	aheads := make([]int32, 0, len(t.clients))
+	for _, info := range t.clients {
+		vheads = append(vheads, info.vhead)
+		aheads = append(aheads, info.ahead)
 	}
 
-	if video != nil {
-		vstream, vok := stream.videos.Get(*video)
-		if vok {
-			t.killOrphanedeheads(&vstream.Stream, true)
+	go func() {
+		stream, ok := t.transcoder.streams.Get(sha)
+		if !ok {
+			return
 		}
-	}
-	if audio != nil {
-		astream, aok := stream.audios.Get(*audio)
-		if aok {
-			t.killOrphanedeheads(&astream.Stream, false)
+
+		if video != nil {
+			if vstream, vok := stream.videos.Get(*video); vok {
+				killOrphanedHeads(&vstream.Stream, vheads)
+			}
 		}
-	}
+		if audio != nil {
+			if astream, aok := stream.audios.Get(*audio); aok {
+				killOrphanedHeads(&astream.Stream, aheads)
+			}
+		}
+	}()
 }
 
-func (t *Tracker) killOrphanedeheads(stream *Stream, is_video bool) {
+func killOrphanedHeads(stream *Stream, viewerHeads []int32) {
 	ctx := context.WithoutCancel(context.Background())
 	stream.lock.Lock()
 	defer stream.lock.Unlock()
@@ -259,11 +280,7 @@ func (t *Tracker) killOrphanedeheads(stream *Stream, is_video bool) {
 		}
 
 		distance := int32(99999)
-		for _, info := range t.clients {
-			ihead := info.ahead
-			if is_video {
-				ihead = info.vhead
-			}
+		for _, ihead := range viewerHeads {
 			distance = min(Abs(ihead-head.segment), distance)
 		}
 		if distance > 20 {

--- a/transcoder/src/transcoder.go
+++ b/transcoder/src/transcoder.go
@@ -2,6 +2,7 @@ package src
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path"
 )
@@ -30,11 +31,25 @@ func NewTranscoder(metadata *MetadataService) (*Transcoder, error) {
 
 	ret := &Transcoder{
 		streams:         NewCMap[string, *FileStream](),
-		clientChan:      make(chan ClientInfo, 10),
+		clientChan:      make(chan ClientInfo, 2048),
 		metadataService: metadata,
 	}
 	ret.tracker = NewTracker(ret)
 	return ret, nil
+}
+
+// track records viewer activity for the tracker goroutine. It is intentionally
+// non-blocking and best-effort: client tracking only drives background cleanup,
+// and every route re-sends fresh info on the next request. Blocking here would
+// couple request latency to the tracker's health - if the tracker ever stalls
+// (e.g. inside a Kill), a blocking send on a full channel would hang every
+// in-flight request (index.m3u8, segments, ...) behind it.
+func (t *Transcoder) track(info ClientInfo) {
+	select {
+	case t.clientChan <- info:
+	default:
+		slog.Warn("client tracking channel full, dropping update", "client", info.client, "sha", info.sha)
+	}
 }
 
 func (t *Transcoder) getFileStream(ctx context.Context, path string, sha string) (*FileStream, error) {
@@ -56,7 +71,7 @@ func (t *Transcoder) GetMaster(ctx context.Context, path string, client string, 
 	if err != nil {
 		return "", err
 	}
-	t.clientChan <- ClientInfo{
+	t.track(ClientInfo{
 		client:    client,
 		profileId: profileId,
 		sessionId: sessionId,
@@ -66,7 +81,7 @@ func (t *Transcoder) GetMaster(ctx context.Context, path string, client string, 
 		audio:     nil,
 		vhead:     -1,
 		ahead:     -1,
-	}
+	})
 	return stream.GetMaster(ctx, client), nil
 }
 
@@ -85,7 +100,7 @@ func (t *Transcoder) GetVideoIndex(
 	if err != nil {
 		return "", err
 	}
-	t.clientChan <- ClientInfo{
+	t.track(ClientInfo{
 		client:    client,
 		profileId: profileId,
 		sessionId: sessionId,
@@ -95,7 +110,7 @@ func (t *Transcoder) GetVideoIndex(
 		audio:     nil,
 		vhead:     -1,
 		ahead:     -1,
-	}
+	})
 	return stream.GetVideoIndex(ctx, video, quality, client)
 }
 
@@ -114,7 +129,7 @@ func (t *Transcoder) GetAudioIndex(
 	if err != nil {
 		return "", err
 	}
-	t.clientChan <- ClientInfo{
+	t.track(ClientInfo{
 		client:    client,
 		profileId: profileId,
 		sessionId: sessionId,
@@ -123,7 +138,7 @@ func (t *Transcoder) GetAudioIndex(
 		audio:     &AudioKey{audio, quality},
 		vhead:     -1,
 		ahead:     -1,
-	}
+	})
 	return stream.GetAudioIndex(ctx, audio, quality, client)
 }
 
@@ -143,7 +158,7 @@ func (t *Transcoder) GetVideoSegment(
 	if err != nil {
 		return "", err
 	}
-	t.clientChan <- ClientInfo{
+	t.track(ClientInfo{
 		client:    client,
 		profileId: profileId,
 		sessionId: sessionId,
@@ -153,7 +168,7 @@ func (t *Transcoder) GetVideoSegment(
 		vhead:     segment,
 		audio:     nil,
 		ahead:     -1,
-	}
+	})
 	return stream.GetVideoSegment(ctx, video, quality, segment)
 }
 
@@ -203,7 +218,7 @@ func (t *Transcoder) GetAudioSegment(
 	if err != nil {
 		return "", err
 	}
-	t.clientChan <- ClientInfo{
+	t.track(ClientInfo{
 		client:    client,
 		profileId: profileId,
 		sessionId: sessionId,
@@ -212,6 +227,6 @@ func (t *Transcoder) GetAudioSegment(
 		audio:     &AudioKey{audio, quality},
 		ahead:     segment,
 		vhead:     -1,
-	}
+	})
 	return stream.GetAudioSegment(ctx, audio, quality, segment)
 }


### PR DESCRIPTION
This fix two reasons the transcoder can become slow to respond:
- remove the SPOF on the tracker, if we fail to dequeue a tracker update simply discard it (it will be re-created a few second later anyway)
- remove all possible IO from the tracker loop, it does the IO on the background
- remove the eager transcode on index.m3u8 retrieval, on huge files it could create lots of transcode at the same time (now it's generated on init.mp4 retrival or first segment)